### PR TITLE
authString bug fix

### DIFF
--- a/lib/rtsp.js
+++ b/lib/rtsp.js
@@ -254,10 +254,10 @@ module.exports.RtspClient = class extends EventEmitter {
                             let ha2 = getMD5Hash(`${requestName}:${this._url}`);
                             let ha3 = getMD5Hash(`${ha1}:${authHeaders.nonce}:${ha2}`);
 
-                            let authString = `Digest username="${this.username}",realm="${authHeaders.realm}",nonce="${authHeaders.nonce}",uri="${this._url}",response="${ha3}"`;
+                            authString = `Digest username="${this.username}",realm="${authHeaders.realm}",nonce="${authHeaders.nonce}",uri="${this._url}",response="${ha3}"`;
                         } else if (type === 'Basic') {
                             // so secure, using Base64 to encrypt it
-                            let authString = 'Basic ' + new Buffer(`${this.username}:${this.password}`).toString('base64');
+                            authString = 'Basic ' + new Buffer(`${this.username}:${this.password}`).toString('base64');
                         }
 
                         resolve(this.request(requestName, assign(headers, {


### PR DESCRIPTION
Hi, 

I was trying to authenticate rstp server. After trying sometime it was not working. 

I jumped to the library and found the problem with variable `authString`. Inside the if statement, `let authString` will create a new authString variable which will be destroyed once we are out of if the statement.

For this reason, the outer authString will remain empty string all the time.